### PR TITLE
Version lock dnsimple module

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "colors": "0.x.x",
     "commander": "1.0.4",
     "datejs": "1.0.0-rc1",
-    "dnsimple": "git://github.com/fvdm/nodejs-dnsimple.git#master",
+    "dnsimple": "git://github.com/fvdm/nodejs-dnsimple.git#0.3.0",
     "easy-table": "0.0.1",
     "event-stream": "3.1.5",
     "eyes": "0.x.x",


### PR DESCRIPTION
I'm going to release the [updated module](https://github.com/fvdm/nodejs-dnsimple/blob/develop/README.md#example) soon into master and npm. Version 0.3.0 is exactly the same as the master at this moment, this change prevents your module from breaking down.

_(the install reports v1.0.0 but you can ignore that)_
